### PR TITLE
updating pip-2

### DIFF
--- a/PIPs/pip-2.md
+++ b/PIPs/pip-2.md
@@ -29,19 +29,6 @@ at nearly precise times in the future.
 This field is similar to `nLockTime` [^1] in Bitcoin.
 However, in Pactus, it is mandatory for all transactions, and it only accepts block numbers as input.
 
-The `LockTime` and `Stamp` fields should be set as follows:
-
-- For scheduled transactions, the `Stamp` field should be set to zero, and the `LockTime` should be set to a block number in future.
-- For stamped transactions, the `LockTime` value should be same as the block number referenced by the Stamp.
-
-While users have the option to set the `Stamp` field to zero for all transactions,
-there is a strong motivation for them to avoid doing so.
-Stamped transactions provide resistance against long-range attack [^2].
-
-Both locked-time and stamped transactions have a limited lifespan,
-and they become invalid once the Transaction-To-Live (TTL) interval expires.
-
 ## References:
 
 [^1]: [https://en.bitcoin.it/wiki/Protocol_documentation#tx](https://en.bitcoin.it/wiki/Protocol_documentation#tx)
-[^2]: [https://pactus.org/learn/transaction/stamping/#long-range-attack](https://pactus.org/learn/transaction/stamping/#long-range-attack)


### PR DESCRIPTION
This PR removes a broken link from PIP-2 and eliminates some unnecessary explanations about the stamp (which no longer exist on the website).