### PR TITLE
PIP-6: Withdraw in favour of PIP-15

### DIFF
--- a/PIPs/pip-6.md
+++ b/PIPs/pip-6.md
@@ -1,7 +1,7 @@
 ---
 pip: 6
 title: In-Memory Storage of Public Keys, Validators, and Accounts using LRU Cache
-status: Draft
+status: Withdraw
 type: Standards Track
 author: Javad Rajabzadeh <ja7ad@live.com>
 created: 2023-09-9


### PR DESCRIPTION
[PIP-15]( https://pips.pactus.org/PIPs/pip-15) offered a more comprehensive solution for caching stored items. Since it is final, this PIP can be withdrawn.