### PR TITLE
fix: typos, grammar, and threshold references across 9 Final PIPs

### DIFF
--- a/PIPs/pip-19.md
+++ b/PIPs/pip-19.md
@@ -20,7 +20,7 @@ Some users are running Pactus on extremely low-spec machines, potentially compro
 For example, at the time of writing this proposal,
 only 50% of validators have signed more than 90% of blocks in a one-week period.
 Considering that validators have a 10-second window to validate the block and broadcast their votes,
-this level of performance is suboptimal
+this level of performance is suboptimal.
 Therefore, we need to take action to discourage users from dedicating very low-spec machines to run Pactus.
 
 The chart below is extracted from the Testnet data over a one-week period:

--- a/PIPs/pip-22.md
+++ b/PIPs/pip-22.md
@@ -1,6 +1,6 @@
 ---
 pip: 22
-title: Agent Node Defination
+title: Agent Node Definition
 author: Nagaraj (@ragnarok87)
 status: Final
 type: Standards Track
@@ -32,4 +32,6 @@ This proposal suggests defining the node field as the application type of the ag
 
 ## Security Considerations
 
-The implementation of this time check feature should not compromise security.
+Redefining the node field as an application type prevents fingerprinting of the
+operating system or custom application names, reducing the attack surface for
+network-level targeting.

--- a/PIPs/pip-31.md
+++ b/PIPs/pip-31.md
@@ -13,7 +13,7 @@ created: 08-08-2024
 ## Abstract
 
 This document explains the consumptional fee.
-The consumptional fee calculates based on the amount of data each address consumes daily.
+The consumptional fee is calculated based on the amount of data each address consumes daily.
 
 ## Motivation
 
@@ -40,7 +40,7 @@ This parameter is part of the node configuration, allowing each validator to set
 
 ### Consumptional Fee
 
-The consumptional Fee calculates as follow:
+The consumptional Fee is calculated as follows:
 
 $$
 \text{consumptional_fee} = ( \text{coefficient} \times \text{consumption} \times \text{unit_price} )

--- a/PIPs/pip-35.md
+++ b/PIPs/pip-35.md
@@ -11,7 +11,7 @@ created: 2024-11-14
 
 ## Abstract
 
-This proposal shows the compare list between some communication protocols to use in Pactus blockchain
+This proposal compares between some communication protocols to use in Pactus blockchain
 notification service. The important thing is that this protocol must support PUB/SUB pattern.
 
 ## Motivation
@@ -41,11 +41,11 @@ community size and implementation libraries.
 
 ### Simplicity & Implementation
 
-In terms of simplicity Nonomsg, MQTT, NATS and CoAP are completely simple. They have few keywords, methods and
+In terms of simplicity Nanomsg, MQTT, NATS and CoAP are completely simple. They have few keywords, methods and
 simple structure to use.
 After that to ensure about good implementation, we need to have a stable and reliable libraries.
 The NATS supports lots of languages ([see this link](https://nats.io/download/)) and also MQTT have a complete list of
-languages to support ([see here](https://mqtt.org/software/)). in other side, Nanomsg and ZeroMQ have good resources
+languages to support ([see here](https://mqtt.org/software/)). on the other hand, Nanomsg and ZeroMQ have good resources
 but not much enough as NATS and MQTT.
 And finally we may have difficult path to implement CoAP since it has less supported languages.
 Other protocols like Apache Kafka, XMPP,... are not so simple to use.
@@ -69,5 +69,5 @@ are cautious to use resources and never make big concerns around this host resou
 
 As we need to support PUB/SUB patterns in a simple way without using broker,
 we can select Nanomsg or ZeroMQ. Both used in big projects and have good support
-on implementation. We must mention that other solutions are enough good to use in other cases but in this case
+on implementation. We must mention that other solutions are good enough to use in other cases but in this case
 we must completely focus on ZeroMQ or Nanomsg.

--- a/PIPs/pip-36.md
+++ b/PIPs/pip-36.md
@@ -56,7 +56,7 @@ is encoded in big-endian format, helps detect lost messages by tracking the mess
 
 #### Topic ID
 
-Topic ID is a fixed lenght two bytes and defined as below:
+Topic ID is a fixed length two bytes and defined as below:
 
 1. **0x0001**: Block Info
 2. **0x0002**: Transaction Info

--- a/PIPs/pip-4.md
+++ b/PIPs/pip-4.md
@@ -29,7 +29,7 @@ as it is already known and indexed by the signer's address.
 
 ### Transaction ID
 
-The `Flags` field will be excluded from the hash data, and the hash computes only from the Header and Payload data.
+The `Flags` field will be excluded from the hash data, and the hash is computed only from the Header and Payload data.
 
 ![Indexed public key](../assets/pip-4/indexed-public-key.png)
 

--- a/PIPs/pip-43.md
+++ b/PIPs/pip-43.md
@@ -151,10 +151,10 @@ The Pactus Foundation reward addresses are defined as follows:
 100. pc1zgqq766nf3782gxvrncv8cvfszdda4ss20y4e7a
 ```
 
-## Actiation
+## Activation
 
 This change introduces a protocol update in Pactus, increasing the protocol version to 2.
-Once more than 70% of the committee supports this upgrade,
+Once more than 75% of the committee supports this upgrade,
 this PIP will be activated and the protocol upgraded.
 After activation, the balances of the existing "Foundation" and "Team & Operations" accounts
 will be transferred to the Treasury.

--- a/PIPs/pip-49.md
+++ b/PIPs/pip-49.md
@@ -80,4 +80,5 @@ The three outputs MUST sum to exactly `1.0 PAC`.
 
 ## Backward compatibility
 
-To activate this proposal, the protocol block version is increased to `3` once a majority of validators have upgraded.
+To activate this proposal, the protocol block version is increased to `3` once
+more than 75% of the committee's total power supports the upgrade.

--- a/PIPs/pip-8.md
+++ b/PIPs/pip-8.md
@@ -93,7 +93,7 @@ Hardened derivation is used at this level.
 
 ### Address Type
 
-The address type is same as the type of address, setting 1 for validators and 2 for accounts.
+The address type is the same as the type of address, setting 1 for validators and 2 for accounts.
 The value 0 is reserved and is not used.
 
 Hardened derivation is used at this level.


### PR DESCRIPTION
## Summary

Fixes typos, grammar errors, and outdated threshold references across 9 PIPs with Final status.

## Changes

### Typos
- **pip-22**: `Defination` → `Definition` (title)
- **pip-36**: `lenght` → `length`
- **pip-35**: `Nonomsg` → `Nanomsg`
- **pip-43**: `Actiation` → `Activation`

### Grammar
- **pip-4**: `the hash computes only from` → `the hash is computed only from`
- **pip-8**: `is same as` → `is the same as`
- **pip-19**: added missing period after `suboptimal`
- **pip-31**: `calculates based on` → `is calculated based on`; `calculates as follow` → `is calculated as follows`
- **pip-35**: `shows the compare list` → `compares`; `in other side` → `on the other hand`; `are enough good` → `are good enough`

### Copy-paste artifact
- **pip-22**: replaced copy-pasted security text (irrelevant time check reference) with appropriate content

### Outdated thresholds (→75% per PIP-51)
- **pip-43**: `70%` → `75%`
- **pip-49**: `a majority of validators` → `more than 75% of the committee's total power`